### PR TITLE
Removes unused call to controller

### DIFF
--- a/assets/javascripts/discourse/controllers/siwe-auth-index.js.es6
+++ b/assets/javascripts/discourse/controllers/siwe-auth-index.js.es6
@@ -26,8 +26,12 @@ export default Controller.extend({
     let provider = Web3Modal.create();
     await provider.providerInit(env);
 
-    const [account, message, signature, avatar] = await provider.runSigningProcess();
-    this.verifySignature(account, message, signature, avatar);
+    try {
+      const [account, message, signature, avatar] = await provider.runSigningProcess();
+      this.verifySignature(account, message, signature, avatar);
+    } catch (e) {
+      console.error(e);
+    }
   },
 
   actions: {

--- a/assets/javascripts/discourse/lib/web3modal.js.es6
+++ b/assets/javascripts/discourse/lib/web3modal.js.es6
@@ -59,7 +59,9 @@ const Web3Modal = EmberObject.extend({
         let ens, avatar;
         try {
             ens = await provider.lookupAddress(address);
-            avatar = await provider.getAvatar(ens);
+            if (ens) {
+                avatar = await provider.getAvatar(ens);
+            }
         } catch (error) {
             console.error(error);
         }

--- a/assets/javascripts/discourse/lib/web3modal.js.es6
+++ b/assets/javascripts/discourse/lib/web3modal.js.es6
@@ -87,7 +87,6 @@ const Web3Modal = EmberObject.extend({
 
         } catch (e) {
             await this.web3Modal.clearCachedProvider();
-            console.error(e);
             throw e;
         }
     },

--- a/assets/javascripts/discourse/routes/siwe-auth-index.js.es6
+++ b/assets/javascripts/discourse/routes/siwe-auth-index.js.es6
@@ -1,10 +1,3 @@
 import Route from "@ember/routing/route";
-import { ajax } from "discourse/lib/ajax";
-import { popupAjaxError } from "discourse/lib/ajax-error";
 
-export default Route.extend({
-  model() {
-    return ajax('/discourse-siwe/message')
-      .catch(popupAjaxError);
-  }
-});
+export default Route.extend();


### PR DESCRIPTION
This removes the empty call to the controller, removes the check for ENS Avatar when there is no domain associated to the account and improves error handling in case of user rejection of the signature. Addresses #8 