### PR TITLE
Discourse 2.9.0 beta5+ compatibility

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -22,7 +22,7 @@ gem 'konstructor', '1.0.2', require: false
 gem 'ffi', '1.15.5', require: false
 gem 'ffi-compiler', '1.0.1', require: false
 gem 'scrypt', '3.0.7', require: false
-gem 'eth', '0.5.1', require: false
+gem 'eth', '0.5.6', require: false
 gem 'siwe', '1.1.2', require: false
 
 class ::SiweAuthenticator < ::Auth::ManagedAuthenticator


### PR DESCRIPTION
eth 0.5.1 is incompatible with the openssl 3.0 gem which leads to issues on 2.9.0 beta5 and up because of this commit
https://github.com/discourse/discourse/commit/eb40173121f6ba85b4bb57fc501a4fa6c2a5a757
