### PR TITLE
Update README.md to be more clear about hosting requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ and projects to discuss proposals, updates, and research. The following is a
 quick guide on how to add Sign-In with Ethereum to your existing Discourse.
 
 ### Requirements
-- A self-hosted Discourse server
+- A Discourse forum that is self-hosted or that is hosted with a provider that allows 
+third party plugins, like [Communiteq](https://www.communiteq.com/).
 
 ### Note
 The Sign-In with Ethereum plugin still requires users to enter an email to 


### PR DESCRIPTION
We have had some people that wanted to move away from Communiteq hosting because the README explicitly says "self hosted", while we happily support this plugin. So this is not meant as guerilla marketing but to avoid confusion.