### PR TITLE
fix: rbsecp256k1 LoadError

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -12,12 +12,12 @@ register_asset 'stylesheets/discourse-siwe.scss'
   ../lib/omniauth/strategies/siwe.rb
 ].each { |path| load File.expand_path(path, __FILE__) }
 
-gem 'pkg-config', '1.4.7', require: false
+gem 'pkg-config', '1.5.0', require: false
 gem 'mkmfmf', '0.4', require: false
 gem 'keccak', '1.3.0', require: false
 gem 'zip', '2.0.2', require: false
 gem 'mini_portile2', '2.8.0', require: false
-gem 'rbsecp256k1', '5.1.0', require: false
+gem 'rbsecp256k1', '5.1.1', require: false
 gem 'konstructor', '1.0.2', require: false
 gem 'ffi', '1.15.5', require: false
 gem 'ffi-compiler', '1.0.1', require: false


### PR DESCRIPTION
what:
- plugin stopped working due to 5xx hitting `/discourse-siwe/message?...`
- sample error from discourse production.log
```
LoadError (cannot load such file -- rbsecp256k1/rbsecp256k1)
app/controllers/application_controller.rb:414:in `block in with_resolved_locale'
app/controllers/application_controller.rb:414:in `with_resolved_locale'
lib/middleware/omniauth_bypass_middleware.rb:74:in `call'
lib/content_security_policy/middleware.rb:12:in `call'
lib/middleware/anonymous_cache.rb:367:in `call'
config/initializers/100-quiet_logger.rb:20:in `call'
config/initializers/100-silence_logger.rb:29:in `call'
lib/middleware/enforce_hostname.rb:24:in `call'
lib/middleware/request_tracker.rb:228:in `call'
```

fix:
- bump rbsecp256k1 to 5.1.1
- rbsecp256k1 5.1.1 in turn requires pkg-config 1.5.0

Related issue: https://github.com/spruceid/discourse-siwe-auth/issues/21