### PR TITLE
Update eth gem and dependencies to get Eth::Ens functionality

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -2,7 +2,7 @@
 
 # name: discourse-siwe
 # about: A discourse plugin to enable users to authenticate via Sign In with Ethereum
-# version: 0.1.1
+# version: 0.1.2
 
 enabled_site_setting :discourse_siwe_enabled
 register_svg_icon 'fab-ethereum'
@@ -13,16 +13,17 @@ register_asset 'stylesheets/discourse-siwe.scss'
 ].each { |path| load File.expand_path(path, __FILE__) }
 
 gem 'pkg-config', '1.5.0', require: false
+gem 'forwardable', '1.3.3', require: false
 gem 'mkmfmf', '0.4', require: false
 gem 'keccak', '1.3.0', require: false
 gem 'zip', '2.0.2', require: false
 gem 'mini_portile2', '2.8.0', require: false
-gem 'rbsecp256k1', '5.1.1', require: false
+gem 'rbsecp256k1', '6.0.0', require: false
 gem 'konstructor', '1.0.2', require: false
 gem 'ffi', '1.15.5', require: false
 gem 'ffi-compiler', '1.0.1', require: false
 gem 'scrypt', '3.0.7', require: false
-gem 'eth', '0.5.6', require: false
+gem 'eth', '0.5.11', require: false
 gem 'siwe', '1.1.2', require: false
 
 class ::SiweAuthenticator < ::Auth::ManagedAuthenticator


### PR DESCRIPTION
We're building the Gitcoin Passport plugin and we need `Eth::Ens::Resolver`.
We need version 0.5.11 of the `eth` gem for that. 
Including that in the Gitcoin Passport plugin causes a version conflict with this plugin since it uses 0.5.6 of the same gem.

We thought it would be the cleanest solution to update the gem and its dependencies in this plugin as well.