### PR TITLE
Bump ffi version dependency because of core change

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,0 +1,1 @@
+< 3.2.0.beta2-dev: f2f580239ba1b1be7db62efc0373971fd9df6886

--- a/plugin.rb
+++ b/plugin.rb
@@ -20,7 +20,7 @@ gem 'zip', '2.0.2', require: false
 gem 'mini_portile2', '2.8.0', require: false
 gem 'rbsecp256k1', '6.0.0', require: false
 gem 'konstructor', '1.0.2', require: false
-gem 'ffi', '1.16.2', require: false
+gem 'ffi', '1.16.3', require: false
 gem 'ffi-compiler', '1.0.1', require: false
 gem 'scrypt', '3.0.7', require: false
 gem 'eth', '0.5.11', require: false

--- a/plugin.rb
+++ b/plugin.rb
@@ -20,7 +20,7 @@ gem 'zip', '2.0.2', require: false
 gem 'mini_portile2', '2.8.0', require: false
 gem 'rbsecp256k1', '6.0.0', require: false
 gem 'konstructor', '1.0.2', require: false
-gem 'ffi', '1.15.5', require: false
+gem 'ffi', '1.16.2', require: false
 gem 'ffi-compiler', '1.0.1', require: false
 gem 'scrypt', '3.0.7', require: false
 gem 'eth', '0.5.11', require: false


### PR DESCRIPTION
ffi was bumped in core so plugins need to follow
https://github.com/discourse/discourse/commit/f085b7aa2c5d6cf8bc1bfc8013415b4301c7f630